### PR TITLE
Add better logs and error on the methods currently used

### DIFF
--- a/interfaces/github.go
+++ b/interfaces/github.go
@@ -1,7 +1,6 @@
 package interfaces
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -58,16 +57,14 @@ func (repo GithubRepository) GetToken(code, givenState, incomingStates string) (
 
 	token, err := repo.oauthConfig.Exchange(oauth2.NoContext, code)
 	if err != nil {
-		// TODO: Log with interactor Logger not yet implemented
-		fmt.Printf("oauthConf.Exchange() failed with '%s'\n", err.Error())
-		return nil, err
+		return nil, fmt.Errorf("oauthConf.Exchange() failed with '%s'\n", err.Error())
 	}
 
 	oauthClient := repo.oauthConfig.Client(oauth2.NoContext, token)
 	client := github.NewClient(oauthClient)
 	user, _, err := client.Users.Get("")
 	if err != nil {
-		return nil, errors.New("Cannot retrieve User data")
+		return nil, fmt.Errorf("Cannot retrieve User data: %s", err.Error())
 	}
 
 	usr := domain.User{

--- a/interfaces/webservice.go
+++ b/interfaces/webservice.go
@@ -139,6 +139,17 @@ func (handler WebServiceHandler) Callback(res http.ResponseWriter, req *http.Req
 	token, err := handler.GHInteractor.GHCallback(oauthwrapper.OauthRequest.Code, "", oauthwrapper.OauthRequest.State)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)
+		errS := fmt.Sprintf("Github oauth error: %s", err.Error())
+
+		log.Println(errS)
+
+		resErr := httpError{
+			Error: errS,
+		}
+
+		respBytes, _ := json.Marshal(resErr)
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(respBytes)
 		return
 	}
 

--- a/interfaces/webservice.go
+++ b/interfaces/webservice.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -100,6 +101,10 @@ type callback struct {
 	Username string `json:"username"`
 }
 
+type httpError struct {
+	Error string `json:"error"`
+}
+
 const integrationURL string = "/api/v1/users/%d/integration"
 
 // Callback manages the Github OAUTH callback
@@ -115,7 +120,19 @@ func (handler WebServiceHandler) Callback(res http.ResponseWriter, req *http.Req
 
 	err := decoder.Decode(&oauthwrapper)
 	if err != nil {
-		res.WriteHeader(http.StatusInternalServerError)
+		res.WriteHeader(422)
+
+		errS := fmt.Sprintf("cannot process request %s", err.Error())
+
+		log.Println(errS)
+
+		resErr := httpError{
+			Error: "cannot process request",
+		}
+
+		respBytes, _ := json.Marshal(resErr)
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(respBytes)
 		return
 	}
 
@@ -150,6 +167,13 @@ func (handler WebServiceHandler) Callback(res http.ResponseWriter, req *http.Req
 	resp, _ := client.Do(request)
 	if resp.StatusCode != http.StatusCreated {
 		res.WriteHeader(http.StatusInternalServerError)
+		resErr := httpError{
+			Error: "cannot save integration",
+		}
+
+		respBytes, _ := json.Marshal(resErr)
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(respBytes)
 		return
 	}
 
@@ -203,7 +227,18 @@ func (handler WebServiceHandler) ShowRepos(res http.ResponseWriter, req *http.Re
 	repos, err := handler.GHInteractor.ShowRepos(username)
 
 	if err != nil {
-		res.WriteHeader(http.StatusNotFound)
+		res.WriteHeader(http.StatusInternalServerError)
+		errS := fmt.Sprintf("Cannot retrieve repositories: %s", err.Error())
+
+		log.Println(errS)
+
+		resErr := httpError{
+			Error: errS,
+		}
+
+		respBytes, _ := json.Marshal(resErr)
+		res.Header().Set("Content-Type", "application/json")
+		res.Write(respBytes)
 		return
 	}
 


### PR DESCRIPTION
This pull request does the following
- Adds logs when the request cannot be processed
- Writes a JSON error in the HTTP response depending on what happened
- Writes 422 which is a status not supported on Go 1.6 
  closes #41 
